### PR TITLE
response: No message-body should be sent on a 204 No Content

### DIFF
--- a/src/priv/httpserverresponse.h
+++ b/src/priv/httpserverresponse.h
@@ -46,6 +46,7 @@ struct HttpServerResponse::Priv
     QIODevice &device;
     HttpResponseFormattingState formattingState;
     Tufao::HttpServerResponse::Options options;
+    int responseStatus;
     Headers headers;
 
     QByteArray http10Buffer;


### PR DESCRIPTION
According to the RFC2616 no message-body should be sent when
the response code 204 is used. When using keep-alive the .NET
stack will break on response parsing after the next request.

Add some hacks to not generate chunked-encoding in the answer
and provide a content-length. The code could use some more
re-use and the question is what should happen when ::write()
or ::end() with data is used on a 204..
