### PR TITLE
Explicitly include <functional> header

### DIFF
--- a/src/priv/workerthreadpool.h
+++ b/src/priv/workerthreadpool.h
@@ -24,6 +24,8 @@
 #include <QtCore/QMap>
 #include <QtCore/QQueue>
 
+#include <functional>
+
 namespace Tufao {
 
 class WorkerThread;


### PR DESCRIPTION
This fixes failing build (at least on ArchLinux).
