### PR TITLE
small fix for windows OS.

### DIFF
--- a/src/httpfileserver.cpp
+++ b/src/httpfileserver.cpp
@@ -356,7 +356,7 @@ inline bool HttpFileServer::handleRequest(HttpServerRequest &request,
         QDir::cleanPath(rootDir
                         + QDir::toNativeSeparators(request.url()
                                                    .path(QUrl::FullyDecoded)))};
-    if (!fileName.startsWith(rootDir + QDir::separator()))
+    if (!fileName.startsWith(rootDir + "/"))
         return false;
 
     {


### PR DESCRIPTION
QDir::cleanPath always return path with forward slash ("/"), but under windows QDir::separator() return back slash ("\"). So the function HttpFileServer::handleRequest always returns false.
