### PR TITLE
Remove trailing path separator from rootDir in HttpFileServer::handler in the same way it is done in the constructor.

### DIFF
--- a/src/httpfileserver.cpp
+++ b/src/httpfileserver.cpp
@@ -340,6 +340,9 @@ std::function<bool(HttpServerRequest&, HttpServerResponse&)>
 HttpFileServer::handler(const QString &rootDir)
 {
     QString dir = rootDir;
+    if (dir.endsWith(QDir::separator()))
+        dir.remove(dir.size() - 1, 1);
+
     return [dir](HttpServerRequest &request, HttpServerResponse &response) {
         return handleRequest(request, response, dir);
     };


### PR DESCRIPTION
When creating an instance of HttpFileServer a trailing path seperator is removed from the rootDir. However, this is not done if the static HttpFileServer::handler is used (e.g. when attaching it to a HttpServerRequestRouter).

Not doing so results in no service from the HttpFileServer.