### PR TITLE
cmake: use debug postfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,14 @@ query_qmake(QT_HOST_DATA QT_DATA_DIR)
 
 set(QT_MKSPECS_DIR ${QT_DATA_DIR}/mkspecs)
 
+# Debug version of library should have 'd' postfix on Windows
+# and '_debug' on Mac OS X
+if(WIN32)
+    set(CMAKE_DEBUG_POSTFIX "d")
+elseif(APPLE)
+    set(CMAKE_DEBUG_POSTFIX "_debug")
+endif()
+
 # Configure options
 option(GENERATE_DOC
     "Use Doxygen to generate the project documentation" OFF


### PR DESCRIPTION
This commit will useful for those who want to place both release and debug version of library in one directory. On Windows 'd' often is used as postfix for debug libraries. On Mac OS X '_debug' is standard.
Qt uses this conventions too.