### PR TITLE
cmake: use full path as install name on Mac OS X

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,7 @@ set_target_properties(
     AUTOMOC ON
     CXX_STANDARD 11
     CXX_STANDARD_REQUIRED ON
+    INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/${libdir}"
 )
 
 if("${CMAKE_VERSION}" VERSION_LESS "2.8.12")


### PR DESCRIPTION
On Mac OS X developer libraries use full path as install name. When some application is linking with such library it will use install name to find library at runtime. Without `INSTALL_NAME_DIR` install name of library will just library name. So I can't start my application. Also correct install name is required for `fixup_bundle` which I use when build dmg with my application.