### PR TITLE
-Wall and -Wextra not appropriate for MSVC

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,12 +25,15 @@ set(tufao_SRC
     classhandler.cpp
 )
 
-add_definitions(-DTUFAO_LIBRARY
-    -Wall
-    -Wextra
-#    -Wpedantic
-#    -Weffc++
-)
+add_definitions(-DTUFAO_LIBRARY)
+if(!MSVC)
+    add_definitions(
+        -Wall
+        -Wextra
+#        -Wpedantic
+#        -Weffc++
+    )
+endif()
 
 add_library("${TUFAO_LIBRARY}" SHARED ${tufao_SRC})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,7 @@ set(tufao_SRC
 )
 
 add_definitions(-DTUFAO_LIBRARY)
-if(!MSVC)
+if(NOT MSVC)
     add_definitions(
         -Wall
         -Wextra


### PR DESCRIPTION
The MSVC compiler shouldn't see the `-Wall` and `-Wextra` flags. MSVC doesn't support the `-Wextra` flag, and this stops compilation. Unlike gcc, MSVC interprets the `-Wall` flag literally, swamping the user with a flood of "warnings" that are not really problems.