### PR TITLE
Use only protocols that are considered secure

### DIFF
--- a/src/httpsserver.cpp
+++ b/src/httpsserver.cpp
@@ -45,7 +45,7 @@ void HttpsServer::setPrivateKey(const QSslKey &key)
 void HttpsServer::incomingConnection(qintptr socketDescriptor)
 {
     QSslSocket *socket = new QSslSocket;
-    socket->setProtocol(QSsl::TlsV1_0);
+    socket->setProtocol(QSsl::SecureProtocols);
     socket->setLocalCertificate(priv->localCertificate);
     socket->setPrivateKey(priv->privateKey);
 


### PR DESCRIPTION
`QSsl` has a configuration option that allows to use only the protocols that are considered secure (for the current Qt version used).
That's way better then defaulting to TLSv1.0.