### PR TITLE
CMakeLists.txt: fix build with Qt 5.11, don't use qt5_use_modules

### DIFF
--- a/examples/cmake/hello-cmake/CMakeLists.txt
+++ b/examples/cmake/hello-cmake/CMakeLists.txt
@@ -13,5 +13,4 @@ find_package(CXX11 REQUIRED)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX11_FLAGS}")
 
 add_executable(${PROJECT_NAME} main.cpp)
-qt5_use_modules(${PROJECT_NAME} Core Network)
-target_link_libraries(${PROJECT_NAME} ${TUFAO_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${TUFAO_LIBRARIES} Qt5::Core Qt5::Network)

--- a/examples/cmake/sample_plugin/plugins/CMakeLists.txt
+++ b/examples/cmake/sample_plugin/plugins/CMakeLists.txt
@@ -9,5 +9,4 @@ set(PLUGIN_HEADERS
 )
 
 add_library(Test SHARED ${PLUGIN_HEADERS} ${PLUGIN_SOURCE})
-qt5_use_modules(Test Core Network)
-target_link_libraries(Test ${TUFAO_LIBRARIES})
+target_link_libraries(Test ${TUFAO_LIBRARIES} Qt5::Test Qt5::Core Qt5::Network)

--- a/examples/cmake/sample_plugin/src/CMakeLists.txt
+++ b/examples/cmake/sample_plugin/src/CMakeLists.txt
@@ -9,5 +9,4 @@ set(${PROJECT_NAME}_HEADERS
 )
 
 add_executable(${PROJECT_NAME} ${${PROJECT_NAME}_HEADERS} ${${PROJECT_NAME}_SOURCE})
-qt5_use_modules(${PROJECT_NAME} Core Network)
-target_link_libraries(${PROJECT_NAME} ${TUFAO_LIBRARIES} ${Test})
+target_link_libraries(${PROJECT_NAME} ${TUFAO_LIBRARIES} ${Test} Qt5::Core Qt5::Network)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 
 add_library("${TUFAO_LIBRARY}" SHARED ${tufao_SRC})
 
-qt5_use_modules("${TUFAO_LIBRARY}" Core Network)
+target_link_libraries("${TUFAO_LIBRARY}" Qt5::Core Qt5::Network)
 
 set_target_properties(
     "${TUFAO_LIBRARY}"

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -20,7 +20,6 @@ set(tests
 )
 
 macro(setup_test_target target)
-    qt5_use_modules("${target}" Core Network Test)
     set_target_properties(
         "${target}"
         PROPERTIES
@@ -43,7 +42,7 @@ macro(setup_test_target target)
 endif()
 
 
-    target_link_libraries("${target}" "${TUFAO_LIBRARY}")
+target_link_libraries("${target}" "${TUFAO_LIBRARY}" Qt5::Core Qt5::Network Qt5::Test)
 
     add_test(NAME "${target}"
         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src"


### PR DESCRIPTION
* replace deprecated (and in 5.11 removed) qt5_use_modules macro usage with
  the list of libraries in target_link_libraries as suggested in:
  https://stackoverflow.com/questions/31172156/what-to-use-instead-of-qt5-use-modules

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>