### PR TITLE
Solve the problem of incomplete data received when using websocket to transmit more than 128K data

### DIFF
--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -824,7 +824,9 @@ inline bool WebSocket::parsePayloadData()
             if (priv->frame.opcode() == FrameType::CONTINUATION) {
                 // CONTINUATION
                 QByteArray chunk(priv->fragment);
+                chunk.append(priv->payload);
                 priv->fragment.clear();
+                priv->payload.clear();
                 emit newMessage(chunk);
             } else {
                 // NON-CONTINUATION

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -824,7 +824,7 @@ inline bool WebSocket::parsePayloadData()
             if (priv->frame.opcode() == FrameType::CONTINUATION) {
                 // CONTINUATION
                 QByteArray chunk(priv->fragment);
-                chunk.append(priv->payload);
+                chunk.append(priv->payload); //last part
                 priv->fragment.clear();
                 priv->payload.clear();
                 emit newMessage(chunk);


### PR DESCRIPTION
Solve the problem of incomplete data received when using websocket to transmit more than 128K data